### PR TITLE
Enable filtering of duplicate entries

### DIFF
--- a/popup.css
+++ b/popup.css
@@ -16,9 +16,15 @@ body {
 	z-index: 10;
 }
 
-.autoplay {
-	position: relative;;
-	float:left;
+#autoplay {
+	position: relative;
+	float: left;
+	width: 40%;
+}
+
+#noduplicates {
+	position: relative;
+	float: right;
 	width: 40%;
 }
 

--- a/popup.html
+++ b/popup.html
@@ -17,7 +17,7 @@
 			</div>
 			<div id="noduplicates">
 					<label class="switch">
-						<input type="checkbox" id="noduplicatesEnabled" />
+						<input type="checkbox" id="noDuplicatesEnabled" />
 						No duplicates
 					</label>
 			</div>

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -8,7 +8,7 @@ var watchNext = {
 		conFig.startLS();
 		chrome.storage.sync.get(function(data){
 			var tempPlaylist = conFig.convertSyncGet(data);
-			if(!(conFig.noDuplicates && tempPlaylist.includes(storeThat))) {
+			if(!(JSON.parse(localStorage.getItem("watchNextNoDuplicates")) == true && tempPlaylist.includes(storeThat))) {
 				tempPlaylist.push(storeThat);
 				conFig.syncSet(tempPlaylist);
 			}

--- a/scripts/background.js
+++ b/scripts/background.js
@@ -8,13 +8,10 @@ var watchNext = {
 		conFig.startLS();
 		chrome.storage.sync.get(function(data){
 			var tempPlaylist = conFig.convertSyncGet(data);
-			//in case of double-, triple-click etc. the item will be added just once
-			// ***NEW*** I am deleting this check, 
-			//because now I will be dealing with multiclicking otherwise
-			//if (!(tempPlaylist[tempPlaylist.length-1]===storeThat)) {
-			tempPlaylist.push(storeThat);
-			conFig.syncSet(tempPlaylist);
-			//}	
+			if(!(conFig.noDuplicates && tempPlaylist.includes(storeThat))) {
+				tempPlaylist.push(storeThat);
+				conFig.syncSet(tempPlaylist);
+			}
 		});
 	},
 

--- a/scripts/popup.js
+++ b/scripts/popup.js
@@ -8,6 +8,7 @@ var playlist={
 	videosArray: [],
 	videosArrayButtons: [],
 	checkbox: {},
+	noDuplicates: {},
 	parentDiv: {},
 	tempPlaylistInfo: [],
 	library: {},
@@ -37,22 +38,27 @@ var playlist={
 	enableDisable: function(){
 		if (this.checkbox.checked){
 			localStorage.setItem('watchNext', 'true');
-		}else{
+		} else {
 			localStorage.setItem('watchNext', 'false');
 		}
 		conFig.setIcon();
 	},
+	
+	noDuplicatesTriggered: function(){
+		if (this.noDuplicates.checked){
+			localStorage.setItem('watchNextNoDuplicates', 'true');
+		} else {
+			localStorage.setItem('watchNextNoDuplicates', 'false');
+		}
+	},
 
 	/*
 	proceed to determine the extension status
-	and check/uncheck the checkbox
+	and check/uncheck the checkboxes
 	*/
-	isCheckboxEnabled: function(){
-		if (JSON.parse(localStorage.getItem("watchNext"))){
-			this.checkbox.checked = true;
-		} else {
-			this.checkbox.checked = false;
-		}
+	loadStorage: function(){
+		this.checkbox.checked = JSON.parse(localStorage.getItem("watchNext")) != false;
+		this.noDuplicatesEnabled.checked = JSON.parse(localStorage.getItem("watchNextNoDuplicates")) == true;
 	},
 
 	/*
@@ -661,15 +667,19 @@ document.addEventListener('DOMContentLoaded', function(){
 
 	// filling the variables
 	playlist.checkbox = document.getElementById('watchNextEnabled');
+	playlist.noDuplicates = document.getElementById('noDuplicatesEnabled');
 	playlist.parentDiv = document.getElementById('watchNext');
 	playlist.historyDiv = document.getElementById('history');
 
 	//tick the checkbox if the extension is enabled
-	playlist.isCheckboxEnabled();
+	playlist.loadStorage();
 
 	//changing extension icon according to the checkbox
 	playlist.checkbox.addEventListener('click', function(){
 		playlist.enableDisable();
+	});
+	playlist.noDuplicates.addEventListener('click', function(){
+		playlist.noDuplicatesTriggered();
 	});
 
 	//starting the generate process
@@ -679,7 +689,6 @@ document.addEventListener('DOMContentLoaded', function(){
 			playlist.tempPlaylistArray = conFig.convertSyncGet(data);
 			playlist.getVideos();
 		});
-		
 	});
 });
 


### PR DESCRIPTION
The idea is to add a switch which, if true, will only add items to the watch-next list if they aren't already in it. But you should definitely test it before merging.

Fixes #10

Needs testing